### PR TITLE
Changement du curseur au survol d'une section dépliable

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,12 @@
             max-width: 600px;
         }
 
+        summary:hover {
+            cursor: pointer;
+            text-decoration: underline;
+            text-decoration-color: rgba(0,0,0,0.7);
+        }
+
         details {
             margin-bottom: 30px;
         }


### PR DESCRIPTION
Indique que les sections sont dépliables en changeant le curseur, et en soulignant l'élément.

Y'a sans doute moyen de faire un soulignement coloré plus joli, mais itérons :)

<img width="637" alt="Capture d’écran 2019-12-04 à 13 48 18" src="https://user-images.githubusercontent.com/179923/70143767-bd02ad80-169c-11ea-9e33-edd405b7dc67.png">
