### PR TITLE
Supprime la mention du 5 décembre

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
 
         <section>
             <p>
-                Ce jeudi 5 décembre 2019, les syndicats appellent à la grève pour lutter contre la réforme des retraites
+                Les syndicats appellent à la grève pour lutter contre la réforme des retraites
                 qui s’annonce. Ces syndicats demandent également une augmentation du salaire minimum, et de manière
                 générale, de meilleures conditions de travail. Ce sont les revendications de la grève.
             </p>


### PR DESCRIPTION
La date est passée, d'autres dates sont annoncées mais autant ne pas mentionner explicitement de date à cet endroit.