### PR TITLE
Ajoute un lien bien visible vers la caisse de grève

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,9 +40,26 @@
 
         h1,
         details,
+        nav,
         footer {
             margin-left: 140px;
             max-width: 600px;
+        }
+
+        nav ul {
+            list-style-type: none;
+            padding: 0;
+        }
+
+        nav ul li {
+	        display: inline;
+        }
+
+        nav ul li a {
+	        border: 1px solid;
+		    border-radius: 5px;
+		    text-decoration: none;
+		    padding: 0.2rem 0.5rem;
         }
 
         summary:hover {
@@ -67,6 +84,7 @@
 
             h1,
             details,
+            nav,
             footer {
                 margin-left: 5px;
             }
@@ -317,6 +335,14 @@
             </p>
         </section>
     </details>
+
+    <nav>
+        <ul>
+            <li>
+                <a href="https://www.lepotcommun.fr/pot/solidarite-financiere">Je participe à la caisse de grève !</a>
+            </li>
+        </ul>
+    </nav>
 
     <footer>
         <p>


### PR DESCRIPTION
C'est un lien vers _une seule_ caisse de grève mais c'est celle qui semble faire l'hunanimité aujourd'hui.

<img width="835" alt="image" src="https://user-images.githubusercontent.com/715910/70330521-09d1ba00-183e-11ea-9420-4b6988496428.png">

resolve #19 