### PR TITLE
Suppression du lien vers caissesdegreve.github.io (non fonctionnel)

### DIFF
--- a/index.html
+++ b/index.html
@@ -346,10 +346,6 @@
         </section>
     </details>
 
-    <a class="cta" href="https://caissesdegreve.github.io/">
-        Je participe à une caisse de grève !
-    </a>
-
     <footer>
         <p>
             <a href="https://greve.cool/">greve.cool</a> – Une page garantie sans trackers – Créée par quelques personnes


### PR DESCRIPTION
Le site caissesdegreve.github.io (et sa redirection caissesdegreve.fr) n'est plus disponible.