### PR TITLE
Ajout date de la prochaine grève

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
 
         <section>
             <p>
-                Les syndicats appellent à la grève le 31 janvier pour lutter contre la réforme des retraites présentée par
+                Les syndicats appellent à la grève le mardi 7 février 2023 pour lutter contre la réforme des retraites présentée par
                 le gouvernement qui reporterait l’âge légal de départ à la retraite à 64 ans, ainsi qu’un
                 allongement accéléré de la durée de cotisation.
             </p>


### PR DESCRIPTION
Source de la date du mardi 7 février 2023 : <https://twitter.com/lacgtcommunique/status/1620499021579296768>