### PR TITLE
Mise à jour de la date de prochaine grève et communiqué

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,9 +192,9 @@
 
         <section>
             <p>
-                Les syndicats appellent à la grève le mardi 7 février 2023 pour lutter contre la réforme des retraites présentée par
-                le gouvernement qui reporterait l’âge légal de départ à la retraite à 64 ans, ainsi qu’un
-                allongement accéléré de la durée de cotisation.
+                Les syndicats <a href="https://solidaires.org/media/documents/communique_intersyndical_11_janvier_2023.pdf">appellent à la grève</a>
+                le jeudi 16 février 2023 pour lutter contre la réforme des retraites présentée par le gouvernement qui reporterait l’âge légal de
+                départ à la retraite à 64 ans, ainsi qu’un allongement accéléré de la durée de cotisation.
             </p>
             <p>
                 Les syndicats dénoncent des mesures injustifiées alors qu’il n’y a aucune urgence financière


### PR DESCRIPTION
- Mise à jour de la date de la prochaine grève annoncée pour le 16 février 2023,
- Ajout du communiqué de l'intersyndicale avec un lien vers le communiqué relayé par Solidaires.