### PR TITLE
Update strike date and communiqué

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,6 +197,12 @@
                 départ à la retraite à 64 ans, ainsi qu’un allongement accéléré de la durée de cotisation.
             </p>
             <p>
+                Les organisations syndicales interprofessionnelles et de jeunesse
+                <a href="https://solidaires.org/media/documents/communiqu%C3%A9_8_mars_intersyndical_DEF.pdf">appellent les travailleuses et travailleurs à se saisir du 8 mars</a>,
+                journée internationale de lutte pour les droits des femmes, pour dénoncer partout l’injustice sociale
+                majeure de cette réforme des retraites envers les femmes.
+            </p>
+            <p>
                 Les syndicats dénoncent des mesures injustifiées alors qu’il n’y a aucune urgence financière
                 et que d’autres solutions de financement sont possibles.
             </p>
@@ -358,7 +364,7 @@
         <p>
             <a href="https://greve.cool/">greve.cool</a> – Une page garantie sans trackers – Créée par quelques personnes
             qui avaient envie d’expliquer à leurs ami·e·s pourquoi elles faisaient grève, et comment ça marche. Dernière
-            mise à jour en janvier 2023. – <a href="#legal">Mentions légales</a>
+            mise à jour en mars 2023. – <a href="#legal">Mentions légales</a>
         </p>
         <p>
             <a href="https://github.com/Signez/grevepointcool/blob/master/README.md">


### PR DESCRIPTION
- Mise à jour des dates de prochaines grèves avec le 8 mars 2023,
- Ajout du communiqué de l'intersyndicale avec un lien vers le communiqué relayé par Solidaires.